### PR TITLE
Update docs and implementation for debug option name change

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ type IRules = IRule | IRuleTypeMap
 function shield(rules?: IRules, options?: IOptions): IMiddleware
 
 export interface IOptions {
+  debug?: boolean
   allowExternalErrors?: boolean
 }
 ```
@@ -209,9 +210,11 @@ const admin = bool =>
 
 | Property | Required | Default | Description                                 |
 | -------- | -------- | ------- | ------------------------------------------- |
-| allowExternalErrors    | false    | true    | Toggles catching internal resolvers errors. |
+| debug / allowExternalErrors   | false    | true    | Toggles catching internal resolvers errors. Currently, both properties perform the same action. |
 
-By default `shield` ensures no internal data is exposed to client if it was not meant to be. Therfore, all thrown errors during execution resolve in `Not Authenticated!` error message if not otherwise specified using `CustomError`. This can be turned off by setting `allowExternalErrors` option to true.
+By default `shield` ensures no internal data is exposed to client if it was not meant to be. Therfore, all thrown errors during execution resolve in `Not Authenticated!` error message if not otherwise specified using `CustomError`. This can be turned off by setting `debug` or `allowExternalErrors` option to true.
+
+Currently, the `allowExternalErrors` aliases the `debug` property.
 
 ### `allow`, `deny`
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ type IRules = IRule | IRuleTypeMap
 function shield(rules?: IRules, options?: IOptions): IMiddleware
 
 export interface IOptions {
-  debug?: boolean
+  allowExternalErrors?: boolean
 }
 ```
 
@@ -209,9 +209,9 @@ const admin = bool =>
 
 | Property | Required | Default | Description                                 |
 | -------- | -------- | ------- | ------------------------------------------- |
-| debug    | false    | true    | Toggles catching internal resolvers errors. |
+| allowExternalErrors    | false    | true    | Toggles catching internal resolvers errors. |
 
-By default `shield` ensures no internal data is exposed to client if it was not meant to be. Therfore, all thrown errors during execution resolve in `Not Authenticated!` error message if not otherwise specified using `CustomError`. This can be turned off by setting `debug` option to true.
+By default `shield` ensures no internal data is exposed to client if it was not meant to be. Therfore, all thrown errors during execution resolve in `Not Authenticated!` error message if not otherwise specified using `CustomError`. This can be turned off by setting `allowExternalErrors` option to true.
 
 ### `allow`, `deny`
 

--- a/README.md
+++ b/README.md
@@ -208,11 +208,11 @@ const admin = bool =>
 
 #### `options`
 
-| Property | Required | Default | Description                                 |
-| -------- | -------- | ------- | ------------------------------------------- |
-| debug / allowExternalErrors   | false    | true    | Toggles catching internal resolvers errors. Currently, both properties perform the same action. |
+| Property            | Required | Default | Description                                 |
+| ------------------- | -------- | ------- | ------------------------------------------- |
+| allowExternalErrors | false    | true    | Toggles catching internal resolvers errors. |
 
-By default `shield` ensures no internal data is exposed to client if it was not meant to be. Therfore, all thrown errors during execution resolve in `Not Authenticated!` error message if not otherwise specified using `CustomError`. This can be turned off by setting `debug` or `allowExternalErrors` option to true.
+By default `shield` ensures no internal data is exposed to client if it was not meant to be. Therfore, all thrown errors during execution resolve in `Not Authenticated!` error message if not otherwise specified using `CustomError`. This can be turned off by setting `allowExternalErrors` option to true.
 
 Currently, the `allowExternalErrors` aliases the `debug` property.
 

--- a/README.md
+++ b/README.md
@@ -214,8 +214,6 @@ const admin = bool =>
 
 By default `shield` ensures no internal data is exposed to client if it was not meant to be. Therfore, all thrown errors during execution resolve in `Not Authenticated!` error message if not otherwise specified using `CustomError`. This can be turned off by setting `allowExternalErrors` option to true.
 
-Currently, the `allowExternalErrors` aliases the `debug` property.
-
 ### `allow`, `deny`
 
 > GraphQL Shield predefined rules.

--- a/src/index.ts
+++ b/src/index.ts
@@ -234,7 +234,7 @@ const wrapResolverWithRule = (options: IOptions) => (
         throw new CustomError('Not Authorised!')
       }
     } catch (err) {
-      if (err instanceof CustomError || options.debug) {
+      if (err instanceof CustomError || options.allowExternalErrors) {
         throw err
       } else {
         throw new Error('Not Authorised!')
@@ -273,7 +273,7 @@ function generateMiddleware(ruleTree: IRules, options: IOptions): IMiddleware {
 
 function normalizeOptions(options: IOptions): IOptions {
   return {
-    debug: options.debug !== undefined ? options.debug : false,
+    allowExternalErrors: options.allowExternalErrors !== undefined ? options.allowExternalErrors : false,
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -234,7 +234,7 @@ const wrapResolverWithRule = (options: IOptions) => (
         throw new CustomError('Not Authorised!')
       }
     } catch (err) {
-      if (err instanceof CustomError || options.allowExternalErrors) {
+      if (err instanceof CustomError || options.debug || options.allowExternalErrors) {
         throw err
       } else {
         throw new Error('Not Authorised!')
@@ -273,6 +273,7 @@ function generateMiddleware(ruleTree: IRules, options: IOptions): IMiddleware {
 
 function normalizeOptions(options: IOptions): IOptions {
   return {
+    debug: options.debug !== undefined ? options.debug : false,
     allowExternalErrors: options.allowExternalErrors !== undefined ? options.allowExternalErrors : false,
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,5 +30,5 @@ export interface IRuleFieldMap {
 export type IRules = IRule | IRuleTypeMap
 
 export interface IOptions {
-  debug?: boolean
+  allowExternalErrors?: boolean
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,5 +30,6 @@ export interface IRuleFieldMap {
 export type IRules = IRule | IRuleTypeMap
 
 export interface IOptions {
+  debug?: boolean,
   allowExternalErrors?: boolean
 }

--- a/test.js
+++ b/test.js
@@ -456,6 +456,27 @@ test('shield:Error: Debug error', async t => {
   await fails(t, schema)(query, 'debugError')
 })
 
+test('shield:Error: AllowExternalErrors error', async t => {
+  const _schema = getSchema()
+  const permissions = shield(
+    {
+      Query: {
+        debugError: rule()(() => true),
+      },
+    },
+    { allowExternalErrors: true },
+  )
+
+  const schema = applyMiddleware(_schema, permissions)
+  const query = `
+    query {
+      debugError
+    }
+  `
+
+  await fails(t, schema)(query, 'debugError')
+})
+
 // Cache:Logic
 
 test('shield:Cache:Logic: All caches', async t => {


### PR DESCRIPTION
The documentation was updated and change the debug option to a more suitable word.

debug -> allowExternalErrors

Nice and simple.