### PR TITLE
fix(docs): Add example for other GraphQL servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ yarn add graphql-shield
 
 ## Example
 
+### GraphQL Yoga
+
 ```ts
 import { GraphQLServer } from 'graphql-yoga'
 import { rule, shield, and, or, not } from 'graphql-shield'
@@ -134,6 +136,19 @@ const server = GraphQLServer({
 })
 
 server.start(() => console.log('Server is running on http://localhost:4000'))
+```
+
+### Others
+
+```ts
+// Permissions...
+
+// Apply permissions middleware with applyMiddleware
+// Giving any schema (instance of GraphQLSchema)
+
+import { applyMiddleware } from 'graphql-middleware';
+
+schema = applyMiddleware(schema, permissions);
 ```
 
 ## API

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ server.start(() => console.log('Server is running on http://localhost:4000'))
 // Giving any schema (instance of GraphQLSchema)
 
 import { applyMiddleware } from 'graphql-middleware';
-
+// schema definition...
 schema = applyMiddleware(schema, permissions);
 ```
 
@@ -229,7 +229,7 @@ const admin = bool =>
 | ------------------- | -------- | ------- | ------------------------------------------- |
 | allowExternalErrors | false    | true    | Toggles catching internal resolvers errors. |
 
-By default `shield` ensures no internal data is exposed to client if it was not meant to be. Therfore, all thrown errors during execution resolve in `Not Authenticated!` error message if not otherwise specified using `CustomError`. This can be turned off by setting `allowExternalErrors` option to true.
+By default `shield` ensures no internal data is exposed to client if it was not meant to be. Therefore, all thrown errors during execution resolve in `Not Authenticated!` error message if not otherwise specified using `CustomError`. This can be turned off by setting `allowExternalErrors` option to true.
 
 ### `allow`, `deny`
 
@@ -285,7 +285,7 @@ const permissions = shield({
 
 ### `Custom Errors`
 
-Shield, by default, catches all errors thrown durign resolver execution. This way we can be 100% sure none of your internal logic will be exposed to the client if it was not meant to be.
+Shield, by default, catches all errors thrown during resolver execution. This way we can be 100% sure none of your internal logic will be exposed to the client if it was not meant to be.
 
 Nevertheless, you can use `CustomError` error types to report your custom error messages to your users.
 


### PR DESCRIPTION
Thank you for your amazing work.

We just get started integrating with this library, but we don't use GraphQL Yoga, in case others looking for examples how to use [graphql-middleware](https://github.com/prismagraphql/graphql-middleware) to apply permissions to their schema, I created this PR.