### PR TITLE
Update README.md for allowExternalErrors options

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ const admin = rule({ cache: 'strict' })(async (parent, args, ctx, info) => {
 
 | Property            | Required | Default | Description                                 |
 | ------------------- | -------- | ------- | ------------------------------------------- |
-| allowExternalErrors | false    | true    | Toggles catching internal resolvers errors. |
+| allowExternalErrors | false    | false    | Toggles catching internal resolvers errors. |
 
 By default `shield` ensures no internal data is exposed to client if it was not meant to be. Therefore, all thrown errors during execution resolve in `Not Authenticated!` error message if not otherwise specified using `CustomError`. This can be turned off by setting `allowExternalErrors` option to true.
 


### PR DESCRIPTION
In the README, it writes that the options `allowExternalErrors ` is settings at true by default but it's not: 
https://github.com/maticzav/graphql-shield/blob/9428a7a5e32cd66d13faea0e7da7db711be2d739/src/index.ts#L312-L318

