### PR TITLE
Add custom errors to logic rules

### DIFF
--- a/src/rules.ts
+++ b/src/rules.ts
@@ -267,7 +267,8 @@ export class RuleOr extends LogicRule {
     const result = await this.evaluate(parent, args, ctx, info, options)
 
     if (result.every(res => res !== true)) {
-      return false
+      const customError = result.find(res => res instanceof Error);
+      return customError || false
     } else {
       return true
     }
@@ -300,7 +301,8 @@ export class RuleAnd extends LogicRule {
       const result = await this.evaluate(parent, args, ctx, info, options)
 
       if (result.some(res => res !== true)) {
-        return false
+        const customError = result.find(res => res instanceof Error)
+        return customError || false
       } else {
         return true
       }

--- a/src/test/logic.test.ts
+++ b/src/test/logic.test.ts
@@ -212,6 +212,53 @@ test('Logic AND - some rules throw, deny.', async t => {
   t.is(res.data, null)
 })
 
+test('Logic AND - some rules return error, deny', async t => {
+  // Schema
+  const typeDefs = `
+    type Query {
+      test: String!
+    }
+  `
+  const resolvers = {
+    Query: {
+      test: () => 'pass',
+    },
+  }
+
+  const schema = makeExecutableSchema({
+    typeDefs,
+    resolvers,
+  })
+
+  // Permissions
+  const testError = new Error('test')
+  const ruleError = rule()(() => testError)
+
+  const permissions = shield(
+    {
+      Query: {
+        test: and(allow, allow, ruleError),
+      },
+    },
+    {
+      debug: true,
+    },
+  )
+
+  const schemaWithPermissions = applyMiddleware(schema, permissions)
+
+  // Execution
+  const query = `
+    query {
+      test
+    }
+  `
+  const res = await graphql(schemaWithPermissions, query)
+
+  t.is(res.data, null)
+  t.is(res.errors[0].message, testError.message)
+})
+
 test('Logic OR - some rules pass, allow.', async t => {
   // Schema
   const typeDefs = `
@@ -290,6 +337,48 @@ test('Logic OR - no rule passes, deny', async t => {
   const res = await graphql(schemaWithPermissions, query)
 
   t.is(res.data, null)
+})
+
+test('Logic OR - some rules return error, deny', async t => {
+  // Schema
+  const typeDefs = `
+    type Query {
+      test: String!
+    }
+  `
+  const resolvers = {
+    Query: {
+      test: () => 'pass',
+    },
+  }
+
+  const schema = makeExecutableSchema({
+    typeDefs,
+    resolvers,
+  })
+
+  // Permissions
+  const testError = new Error('test')
+  const ruleError = rule()(() => testError)
+
+  const permissions = shield({
+    Query: {
+      test: or(deny, deny, ruleError),
+    },
+  })
+
+  const schemaWithPermissions = applyMiddleware(schema, permissions)
+
+  // Execution
+  const query = `
+    query {
+      test
+    }
+  `
+  const res = await graphql(schemaWithPermissions, query)
+
+  t.is(res.data, null)
+  t.is(res.errors[0].message, testError.message)
 })
 
 test('Logic NOT - true -> false, deny.', async t => {


### PR DESCRIPTION
Hey @maticzav! Sorry for delay with docs and thanks for the new release! 👍 

I've upgraded graphql-shield in my project and discovered that there are no custom errors for the logic rules.
This PR's adds custom errors to logic rules.

Current logic: is first encountered error will be returned in case if logic rules fails.

I am not sure if it is best possible solution but do not know how to work arround multiple errors with `throw`.

Let me know if you have any thoughts.

PS. I see there are docs for custom errors for regular rules. Should I add one for logic rules in case PR merged?