### PR TITLE
correct rule function declaration in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ schema = applyMiddleware(schema, permissions)
 
 ```ts
 // Rule
-function rule(name?: string, options?: IRuleOptions)(func: IRuleFunction): Rule
+function rule(name?: string, options?: IRuleOptions): (func: IRuleFunction) => Rule
 
 export type IFragment = string
 export type ICacheOptions = 'strict' | 'contextual' | 'no_cache' | boolean


### PR DESCRIPTION
`function rule(name?: string, options?: IRuleOptions)(func: IRuleFunction): Rule` is not a correct declaration.

`rule` should be a function declared as 

```typescript
function rule(name?: string, options?: IRuleOptions): IResult { ... }
```
And, `IResult` is a function declaration as `(func: IRuleFunction) => Rule`.

So the correct declaraion should be:

```typescript
function rule(name?: string, options?: IRuleOptions): (func: IRuleFunction) => Rule
```