### PR TITLE
Default rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ export interface IOptions {
   allowExternalErrors?: boolean
   fallbackRule?: ShieldRule
   graphiql?: boolean
-  fallback?: string | Error
+  fallbackError?: string | Error
 }
 ```
 
@@ -318,7 +318,7 @@ const server = GraphQLServer({
 | debug               | false    | false                   | Toggle debug mode.                                          |
 | fallbackRule           | false    | allow                   | The default rule for every "rule-undefined" field.               |
 | graphiql            | false    | false                   | Allow introspection query regardless of `fallbackRule` option. |
-| fallback            | false    | Error('Not Authorised') | Error Permission system fallbacks to.                       |
+| fallbackError            | false    | Error('Not Authorised') | Error Permission system fallbacks to.                       |
 
 By default `shield` ensures no internal data is exposed to client if it was not meant to be. Therefore, all thrown errors during execution resolve in `Not Authenticated!` error message if not otherwise specified using `error` wrapper. This can be turned off by setting `allowExternalErrors` option to true.
 
@@ -372,9 +372,9 @@ const permissions = shield({
 })
 ```
 
-### `Global Fallback`
+### `Global Fallback Error`
 
-GraphQL Shield allows you to set a globally defined fallback that is used instead of `Not Authorised!` default response. This might be particularly useful for localisation. You can use `string` or even custom `Error` to define it.
+GraphQL Shield allows you to set a globally defined fallback error that is used instead of `Not Authorised!` default response. This might be particularly useful for localisation. You can use `string` or even custom `Error` to define it.
 
 ```ts
 const permissions = shield(
@@ -384,7 +384,7 @@ const permissions = shield(
     },
   },
   {
-    fallback: 'To je napaka!', // meaning "This is a mistake" in Slovene.
+    fallbackError: 'To je napaka!', // meaning "This is a mistake" in Slovene.
   },
 )
 
@@ -395,7 +395,7 @@ const permissions = shield(
     },
   },
   {
-    fallback: new CustomError('You are something special!'),
+    fallbackError: new CustomError('You are something special!'),
   },
 )
 ```

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ function shield(rules?: IRules, options?: IOptions): IMiddleware
 export interface IOptions {
   debug?: boolean
   allowExternalErrors?: boolean
-  defaultRule?: ShieldRule
+  fallbackRule?: ShieldRule
   graphiql?: boolean
   fallback?: string | Error
 }
@@ -316,8 +316,8 @@ const server = GraphQLServer({
 | ------------------- | -------- | ----------------------- | ----------------------------------------------------------- |
 | allowExternalErrors | false    | false                   | Toggle catching internal errors.                            |
 | debug               | false    | false                   | Toggle debug mode.                                          |
-| defaultRule           | false    | allow                   | The default rule for every "rule-undefined" field.               |
-| graphiql            | false    | false                   | Allow introspection query regardless of `defaultRule` option. |
+| fallbackRule           | false    | allow                   | The default rule for every "rule-undefined" field.               |
+| graphiql            | false    | false                   | Allow introspection query regardless of `fallbackRule` option. |
 | fallback            | false    | Error('Not Authorised') | Error Permission system fallbacks to.                       |
 
 By default `shield` ensures no internal data is exposed to client if it was not meant to be. Therefore, all thrown errors during execution resolve in `Not Authenticated!` error message if not otherwise specified using `error` wrapper. This can be turned off by setting `allowExternalErrors` option to true.
@@ -427,7 +427,7 @@ const permissions = shield(
     },
   },
   {
-    defaultRule: deny,
+    fallbackRule: deny,
   },
 )
 
@@ -465,7 +465,7 @@ const { schema, fragmentReplacements } = applyMiddleware(schema, permissions)
 
 ### `Whitelisting vs Blacklisting`
 
-Shield allows you to lock-in your schema. This way, you can seamleslly develop and publish your work without worrying about exposing your data. To lock in your service simply set `defaultRule` to `deny` like this;
+Shield allows you to lock-in your schema. This way, you can seamleslly develop and publish your work without worrying about exposing your data. To lock in your service simply set `fallbackRule` to `deny` like this;
 
 ```ts
 const typeDefs = `
@@ -496,7 +496,7 @@ const permissions = shield({
     id: allow,
     name: allow,
   },
-}, {defaultRule: deny})
+}, {fallbackRule: deny})
 ```
 
 > You can achieve same functionality by setting every "rule-undefined" field to `deny` the request.

--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ const server = GraphQLServer({
 | graphiql            | false    | false                   | Allow introspection query regardless of `fallbackRule` option. |
 | fallbackError            | false    | Error('Not Authorised') | Error Permission system fallbacks to.                       |
 
-By default `shield` ensures no internal data is exposed to client if it was not meant to be. Therefore, all thrown errors during execution resolve in `Not Authenticated!` error message if not otherwise specified using `error` wrapper. This can be turned off by setting `allowExternalErrors` option to true.
+By default `shield` ensures no internal data is exposed to client if it was not meant to be. Therefore, all thrown errors during execution resolve in `Not Authorised!` error message if not otherwise specified using `error` wrapper. This can be turned off by setting `allowExternalErrors` option to true.
 
 ### `allow`, `deny`
 

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ function shield(rules?: IRules, options?: IOptions): IMiddleware
 export interface IOptions {
   debug?: boolean
   allowExternalErrors?: boolean
-  whitelist?: boolean
+  defaultRule?: ShieldRule
   graphiql?: boolean
   fallback?: string | Error
 }
@@ -264,7 +264,7 @@ const admin = rule({ cache: 'strict' })(async (parent, args, ctx, info) => {
 
 Shield, by default, catches all errors thrown during resolver execution. This way we can be 100% sure none of your internal logic can be exposed to the client if it was not meant to be.
 
-To return custom error messages to your client, you can return error instead of throwing it. This way, Shield knows it's not a bug but rather a design decision under control. 
+To return custom error messages to your client, you can return error instead of throwing it. This way, Shield knows it's not a bug but rather a design decision under control.
 
 You can return custom error from resolver or from rule itself. Rules that return error are treated as failing, therefore not processing any further resolvers.
 
@@ -316,8 +316,8 @@ const server = GraphQLServer({
 | ------------------- | -------- | ----------------------- | ----------------------------------------------------------- |
 | allowExternalErrors | false    | false                   | Toggle catching internal errors.                            |
 | debug               | false    | false                   | Toggle debug mode.                                          |
-| whitelist           | false    | false                   | Whitelist rules instead of blacklisting them.               |
-| graphiql            | false    | false                   | Allow introspection query regardless of `whitelist` option. |
+| defaultRule           | false    | allow                   | The default rule for every "rule-undefined" field.               |
+| graphiql            | false    | false                   | Allow introspection query regardless of `defaultRule` option. |
 | fallback            | false    | Error('Not Authorised') | Error Permission system fallbacks to.                       |
 
 By default `shield` ensures no internal data is exposed to client if it was not meant to be. Therefore, all thrown errors during execution resolve in `Not Authenticated!` error message if not otherwise specified using `error` wrapper. This can be turned off by setting `allowExternalErrors` option to true.
@@ -427,7 +427,7 @@ const permissions = shield(
     },
   },
   {
-    whitelist: true,
+    defaultRule: deny,
   },
 )
 
@@ -465,7 +465,7 @@ const { schema, fragmentReplacements } = applyMiddleware(schema, permissions)
 
 ### `Whitelisting vs Blacklisting`
 
-Shield allows you to lock-in your schema. This way, you can seamleslly develop and publish your work without worrying about exposing your data. To lock in your service simply set `whitelist` to `true` like this;
+Shield allows you to lock-in your schema. This way, you can seamleslly develop and publish your work without worrying about exposing your data. To lock in your service simply set `defaultRule` to `deny` like this;
 
 ```ts
 const typeDefs = `
@@ -496,7 +496,7 @@ const permissions = shield({
     id: allow,
     name: allow,
   },
-})
+}, {defaultRule: deny})
 ```
 
 > You can achieve same functionality by setting every "rule-undefined" field to `deny` the request.

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -125,7 +125,7 @@ function applyRuleToType(
         return {
           ...middleware,
           [field]: generateFieldMiddlewareFromRule(
-            options.defaultRule,
+            options.fallbackRule,
             options,
           ),
         }
@@ -146,7 +146,7 @@ function applyRuleToType(
         return {
           ...middleware,
           [field]: generateFieldMiddlewareFromRule(
-            options.defaultRule,
+            options.fallbackRule,
             options,
           ),
         }

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -43,7 +43,7 @@ function generateFieldMiddlewareFromRule(
       if (res === true) {
         return resolve(parent, args, ctx, info)
       } else if (res === false) {
-        return options.fallback
+        return options.fallbackError
       } else {
         return res
       }
@@ -53,7 +53,7 @@ function generateFieldMiddlewareFromRule(
       } else if (options.allowExternalErrors) {
         return err
       } else {
-        return options.fallback
+        return options.fallbackError
       }
     }
   }

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -4,7 +4,7 @@ import {
   IMiddlewareGeneratorConstructor,
 } from 'graphql-middleware'
 import { GraphQLSchema, GraphQLObjectType, isObjectType } from 'graphql'
-import { allow } from './constructors'
+import { allow, deny } from './constructors'
 import { IRules, IOptions, ShieldRule, IRuleFieldMap } from './types'
 import { isRuleFunction, isRuleFieldMap, isRule, isLogicRule } from './utils'
 import { ValidationError } from './validation'
@@ -125,7 +125,7 @@ function applyRuleToType(
         return {
           ...middleware,
           [field]: generateFieldMiddlewareFromRule(
-            options.fallbackRule,
+            options.whitelist ? deny : options.fallbackRule,
             options,
           ),
         }
@@ -146,7 +146,7 @@ function applyRuleToType(
         return {
           ...middleware,
           [field]: generateFieldMiddlewareFromRule(
-            options.fallbackRule,
+            options.whitelist ? deny : options.fallbackRule,
             options,
           ),
         }

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -4,7 +4,7 @@ import {
   IMiddlewareGeneratorConstructor,
 } from 'graphql-middleware'
 import { GraphQLSchema, GraphQLObjectType, isObjectType } from 'graphql'
-import { allow, deny } from './constructors'
+import { allow } from './constructors'
 import { IRules, IOptions, ShieldRule, IRuleFieldMap } from './types'
 import { isRuleFunction, isRuleFieldMap, isRule, isLogicRule } from './utils'
 import { ValidationError } from './validation'
@@ -125,7 +125,7 @@ function applyRuleToType(
         return {
           ...middleware,
           [field]: generateFieldMiddlewareFromRule(
-            options.whitelist ? deny : allow,
+            options.defaultRule,
             options,
           ),
         }
@@ -146,7 +146,7 @@ function applyRuleToType(
         return {
           ...middleware,
           [field]: generateFieldMiddlewareFromRule(
-            options.whitelist ? deny : allow,
+            options.defaultRule,
             options,
           ),
         }

--- a/src/shield.ts
+++ b/src/shield.ts
@@ -19,8 +19,18 @@ function normalizeOptions(options: IOptionsConstructor): IOptions {
     )
   }
 
+  if (options.fallback !== undefined && options.fallbackError !== undefined) {
+    throw new Error(
+      'You specified both `fallback` and `fallbackError`. Please use one or the other.',
+    )
+  }
+
   if (typeof options.fallback === 'string') {
     options.fallback = new Error(options.fallback)
+  }
+
+  if (typeof options.fallbackError === 'string') {
+    options.fallbackError = new Error(options.fallbackError)
   }
 
   return {
@@ -33,10 +43,13 @@ function normalizeOptions(options: IOptionsConstructor): IOptions {
     fallbackRule:
       options.fallbackRule !== undefined ? options.fallbackRule : allow,
     graphiql: options.graphiql !== undefined ? options.graphiql : false,
-    fallback:
-      options.fallback !== undefined
-        ? options.fallback
-        : new Error('Not Authorised!'),
+    fallback: undefined,
+    fallbackError:
+      options.fallbackError !== undefined
+        ? options.fallbackError
+        : options.fallback !== undefined
+          ? options.fallback
+          : new Error('Not Authorised!'),
   }
 }
 

--- a/src/shield.ts
+++ b/src/shield.ts
@@ -23,8 +23,8 @@ function normalizeOptions(options: IOptionsConstructor): IOptions {
       options.allowExternalErrors !== undefined
         ? options.allowExternalErrors
         : false,
-    defaultRule:
-      options.defaultRule !== undefined ? options.defaultRule : allow,
+    fallbackRule:
+      options.fallbackRule !== undefined ? options.fallbackRule : allow,
     graphiql: options.graphiql !== undefined ? options.graphiql : false,
     fallback:
       options.fallback !== undefined

--- a/src/shield.ts
+++ b/src/shield.ts
@@ -13,6 +13,12 @@ import { allow } from './constructors'
  *
  */
 function normalizeOptions(options: IOptionsConstructor): IOptions {
+  if (options.whitelist !== undefined && options.fallbackRule !== undefined) {
+    throw new Error(
+      'You specified both `whitelist` and `fallbackRule`. Please use one or the other.',
+    )
+  }
+
   if (typeof options.fallback === 'string') {
     options.fallback = new Error(options.fallback)
   }
@@ -23,6 +29,7 @@ function normalizeOptions(options: IOptionsConstructor): IOptions {
       options.allowExternalErrors !== undefined
         ? options.allowExternalErrors
         : false,
+    whitelist: options.whitelist !== undefined ? options.whitelist : false,
     fallbackRule:
       options.fallbackRule !== undefined ? options.fallbackRule : allow,
     graphiql: options.graphiql !== undefined ? options.graphiql : false,

--- a/src/shield.ts
+++ b/src/shield.ts
@@ -2,6 +2,7 @@ import { middleware, IMiddlewareGenerator } from 'graphql-middleware'
 import { validateRules } from './utils'
 import { IRules, IOptions, IOptionsConstructor } from './types'
 import { generateMiddlewareGeneratorFromRuleTree } from './generator'
+import { allow } from './constructors'
 
 /**
  *
@@ -22,7 +23,8 @@ function normalizeOptions(options: IOptionsConstructor): IOptions {
       options.allowExternalErrors !== undefined
         ? options.allowExternalErrors
         : false,
-    whitelist: options.whitelist !== undefined ? options.whitelist : false,
+    defaultRule:
+      options.defaultRule !== undefined ? options.defaultRule : allow,
     graphiql: options.graphiql !== undefined ? options.graphiql : false,
     fallback:
       options.fallback !== undefined

--- a/src/test/generator.test.ts
+++ b/src/test/generator.test.ts
@@ -48,7 +48,7 @@ test('Generator - whitelist permissions.', async t => {
       },
     },
     {
-      defaultRule: deny,
+      fallbackRule: deny,
       debug: true,
     },
   )
@@ -210,7 +210,7 @@ test('Generator - custom default permissions.', async t => {
       },
     },
     {
-      defaultRule: customRule,
+      fallbackRule: customRule,
       debug: true,
     },
   )

--- a/src/test/graphiql.test.ts
+++ b/src/test/graphiql.test.ts
@@ -28,7 +28,7 @@ test('GraphiQL introspection query works.', async t => {
   const permissions = shield(
     {},
     {
-      defaultRule: deny,
+      fallbackRule: deny,
       graphiql: true,
     },
   )
@@ -68,7 +68,7 @@ test('GraphiQL normal query works.', async t => {
       },
     },
     {
-      defaultRule: deny,
+      fallbackRule: deny,
       graphiql: true,
     },
   )

--- a/src/test/graphiql.test.ts
+++ b/src/test/graphiql.test.ts
@@ -68,6 +68,89 @@ test('GraphiQL normal query works.', async t => {
       },
     },
     {
+      whitelist: true,
+      graphiql: true,
+    },
+  )
+
+  const schemaWithPermissions = applyMiddleware(schema, permissions)
+
+  // Execution
+  const query = `
+    query {
+      test
+    }
+  `
+  const res = await graphql(schemaWithPermissions, query)
+
+  t.deepEqual(res.data, {
+    test: 'pass',
+  })
+})
+
+test('GraphiQL introspection query works with fallbackRule set to deny.', async t => {
+  // Schema
+  const typeDefs = `
+    type Query {
+      test: String!
+      type: TestType!
+    }
+
+    type TestType {
+      fieldString: String!
+      fieldInt: Int!
+    }
+  `
+
+  const schema = makeExecutableSchema({
+    typeDefs,
+    resolvers: {},
+  })
+
+  // Permissions
+  const permissions = shield(
+    {},
+    {
+      whitelist: true,
+      graphiql: true,
+    },
+  )
+
+  const schemaWithPermissions = applyMiddleware(schema, permissions)
+
+  // Execution
+  const res = await graphql(schemaWithPermissions, getIntrospectionQuery())
+
+  t.deepEqual(res.errors, undefined)
+})
+
+test('GraphiQL normal query works with fallbackRule set to deny.', async t => {
+  // Schema
+  const typeDefs = `
+    type Query {
+      test: String!
+    }
+  `
+
+  const resolvers = {
+    Query: {
+      test: () => 'pass',
+    },
+  }
+
+  const schema = makeExecutableSchema({
+    typeDefs,
+    resolvers,
+  })
+
+  // Permissions
+  const permissions = shield(
+    {
+      Query: {
+        test: allow,
+      },
+    },
+    {
       fallbackRule: deny,
       graphiql: true,
     },

--- a/src/test/graphiql.test.ts
+++ b/src/test/graphiql.test.ts
@@ -3,7 +3,7 @@ import { graphql, getIntrospectionQuery } from 'graphql'
 import { applyMiddleware } from 'graphql-middleware'
 import { makeExecutableSchema } from 'graphql-tools'
 import { shield } from '../index'
-import { allow } from '../constructors'
+import { allow, deny } from '../constructors'
 
 test('GraphiQL introspection query works.', async t => {
   // Schema
@@ -28,7 +28,7 @@ test('GraphiQL introspection query works.', async t => {
   const permissions = shield(
     {},
     {
-      whitelist: true,
+      defaultRule: deny,
       graphiql: true,
     },
   )
@@ -68,7 +68,7 @@ test('GraphiQL normal query works.', async t => {
       },
     },
     {
-      whitelist: true,
+      defaultRule: deny,
       graphiql: true,
     },
   )

--- a/src/test/logic.test.ts
+++ b/src/test/logic.test.ts
@@ -618,6 +618,7 @@ test('Logic rule by default resolves to false', async t => {
       fallbackRule: undefined,
       graphiql: true,
       fallback: new Error(),
+      fallbackError: new Error(),
     },
   )
 

--- a/src/test/logic.test.ts
+++ b/src/test/logic.test.ts
@@ -614,7 +614,7 @@ test('Logic rule by default resolves to false', async t => {
     {
       allowExternalErrors: false,
       debug: false,
-      defaultRule: allow,
+      fallbackRule: allow,
       graphiql: true,
       fallback: new Error(),
     },

--- a/src/test/logic.test.ts
+++ b/src/test/logic.test.ts
@@ -614,7 +614,8 @@ test('Logic rule by default resolves to false', async t => {
     {
       allowExternalErrors: false,
       debug: false,
-      fallbackRule: allow,
+      whitelist: false,
+      fallbackRule: undefined,
       graphiql: true,
       fallback: new Error(),
     },

--- a/src/test/logic.test.ts
+++ b/src/test/logic.test.ts
@@ -614,7 +614,7 @@ test('Logic rule by default resolves to false', async t => {
     {
       allowExternalErrors: false,
       debug: false,
-      whitelist: false,
+      defaultRule: allow,
       graphiql: true,
       fallback: new Error(),
     },

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,7 +69,7 @@ export type IRules = ShieldRule | IRuleTypeMap
 export interface IOptions {
   debug: boolean
   allowExternalErrors: boolean
-  whitelist: boolean
+  defaultRule: ShieldRule
   graphiql: boolean
   fallback: Error
 }
@@ -77,7 +77,7 @@ export interface IOptions {
 export interface IOptionsConstructor {
   debug?: boolean
   allowExternalErrors?: boolean
-  whitelist?: boolean
+  defaultRule?: ShieldRule
   graphiql?: boolean
   fallback?: string | Error
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,7 +69,7 @@ export type IRules = ShieldRule | IRuleTypeMap
 export interface IOptions {
   debug: boolean
   allowExternalErrors: boolean
-  defaultRule: ShieldRule
+  fallbackRule: ShieldRule
   graphiql: boolean
   fallback: Error
 }
@@ -77,7 +77,7 @@ export interface IOptions {
 export interface IOptionsConstructor {
   debug?: boolean
   allowExternalErrors?: boolean
-  defaultRule?: ShieldRule
+  fallbackRule?: ShieldRule
   graphiql?: boolean
   fallback?: string | Error
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,6 +69,7 @@ export type IRules = ShieldRule | IRuleTypeMap
 export interface IOptions {
   debug: boolean
   allowExternalErrors: boolean
+  whitelist: boolean
   fallbackRule: ShieldRule
   graphiql: boolean
   fallback: Error
@@ -77,6 +78,7 @@ export interface IOptions {
 export interface IOptionsConstructor {
   debug?: boolean
   allowExternalErrors?: boolean
+  whitelist?: boolean
   fallbackRule?: ShieldRule
   graphiql?: boolean
   fallback?: string | Error

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,6 +73,7 @@ export interface IOptions {
   fallbackRule: ShieldRule
   graphiql: boolean
   fallback: Error
+  fallbackError: Error
 }
 
 export interface IOptionsConstructor {
@@ -82,6 +83,7 @@ export interface IOptionsConstructor {
   fallbackRule?: ShieldRule
   graphiql?: boolean
   fallback?: string | Error
+  fallbackError?: string | Error
 }
 
 export declare function shield<TSource = any, TContext = any, TArgs = any>(


### PR DESCRIPTION
I thought I'd put up this PR for discussion as one possible solution to https://github.com/maticzav/graphql-shield/issues/167.

## Summary of Changes

This diff replaces `shield`'s `whitelist` option with a new option, `defaultRule`. If set, `defaultRule` needs to be a `ShieldRule`; if omitted, it defaults to `allow`, which mimics the current behavior of blacklisting by default if `whitelist` is omitted. Since this is a breaking change for people using `whitelist`, a major version bump would be required.

People currently explicitly setting `whitelist` would need to update their code to:

* `{ whitelist: true }`  -> `{ defaultRule: deny }`
* `{ whitelist: false }` -> `{ defaultRule: allow }`

to get the current behavior.

## Motivation

It should be possible to set a default rule other than simple allow/deny. As mentioned in the linked issue, a use case is setting a custom rule on the majority of fields, with some explicit exceptions.

Thoughts?