### PR TITLE
Add per type fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,30 @@ const server = GraphQLServer({
 
 > If you wish to see errors thrown inside resolvers, you can set `allowExternalErrors` option to `true`. This way, Shield won't hide custom errors thrown during query resolving.
 
+#### per type wildcard rule
+
+There is an option to specify a rule that will be applied to all fields of a type (`Query`, `Mutatation`, ...) that do not specify a rule.
+It is similar to the `options.fallbackRule` but allows you to specify a `fallbackRule` per type.
+
+```ts
+// this will only allow query1 and query2.
+// query3 for instance will be denied
+// it will also deny every mutation
+// (you can still use `fallbackRule` option with it)
+const permissions = shield({
+  Query: {
+    "*": deny
+    query1: allow,
+    query2: allow,
+  },
+  Mutation: {
+    "*": deny
+  },
+}, {
+  fallbackRule: allow
+})
+```
+
 #### `options`
 
 | Property            | Required | Default                  | Description                                        |

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -139,7 +139,6 @@ function applyRuleToType(
 
     /* Generation */
 
-    // fieldMap= [ query1, query2, ... ]
     const middleware = Object.keys(fieldMap).reduce(
       (middleware, field) => ({
         ...middleware,

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -121,6 +121,9 @@ function applyRuleToType(
     /* Apply rules assigned to each field to each field */
     const fieldMap = type.getFields()
 
+    /* Extract default type wildcard if any and remove it for validation */
+    const defaultTypeRule = rules['*']
+    delete rules['*']
     /* Validation */
 
     const fieldErrors = Object.keys(rules)
@@ -136,11 +139,12 @@ function applyRuleToType(
 
     /* Generation */
 
+    // fieldMap= [ query1, query2, ... ]
     const middleware = Object.keys(fieldMap).reduce(
       (middleware, field) => ({
         ...middleware,
         [field]: generateFieldMiddlewareFromRule(
-          withDefault(options.fallbackRule)(rules[field]),
+          withDefault(defaultTypeRule || options.fallbackRule)(rules[field]),
           options,
         ),
       }),

--- a/tests/generator.test.ts
+++ b/tests/generator.test.ts
@@ -178,4 +178,82 @@ describe('generates correct middleware', () => {
     })
     expect(allowMock).toBeCalledTimes(1)
   })
+
+  test('correctly applies wildcard rule to type', async () => {
+    /* Schema */
+
+    const typeDefs = `
+      type Query {
+        a: String
+        b: String
+        type: Type
+      }
+      type Type {
+        field1: String
+        field2: String
+      }
+    `
+
+    const resolvers = {
+      Query: {
+        a: () => 'a',
+        b: () => 'b',
+        type: () => ({
+          field1: 'field1',
+          field2: 'field2',
+        }),
+      },
+    }
+
+    const schema = makeExecutableSchema({ typeDefs, resolvers })
+
+    /* Permissions */
+
+    const allowMock = jest.fn().mockResolvedValue(true)
+    const defaultQueryMock = jest.fn().mockResolvedValue(true)
+    const defaultTypeMock = jest.fn().mockResolvedValue(true)
+
+    const permissions = shield({
+      Query: {
+        a: rule({ cache: 'no_cache' })(allowMock),
+        type: rule({ cache: 'no_cache' })(jest.fn().mockResolvedValue(true)),
+        '*': rule({ cache: 'no_cache' })(defaultQueryMock),
+      },
+      Type: {
+        '*': rule({ cache: 'no_cache' })(defaultTypeMock),
+      },
+    })
+
+    const schemaWithPermissions = applyMiddleware(schema, permissions)
+
+    /* Execution */
+    const query = `
+      query {
+        a
+        b
+        type {
+          field1
+          field2
+        }
+      }
+    `
+
+    const res = await graphql(schemaWithPermissions, query)
+
+    /* Tests */
+
+    expect(res).toEqual({
+      data: {
+        a: 'a',
+        b: 'b',
+        type: {
+          field1: 'field1',
+          field2: 'field2',
+        },
+      },
+    })
+    expect(allowMock).toBeCalledTimes(1)
+    expect(defaultQueryMock).toBeCalledTimes(1)
+    expect(defaultTypeMock).toBeCalledTimes(2)
+  })
 })


### PR DESCRIPTION
We are integrating your library in our project and it does work well.
Still, we wanted to achieve per type fallback (in addition on the global option eventually) without having to declare every field since our API is getting quite large.

We did not find a way to achieve this with the current state of the library. So we implemented the following feature.
Maybe there already is a way to achieve this w/o adding this code, if so we missed it.
If not, here is our proposal for that: 

- use a specific "field name": `*` which can be used per type (root types and "regular types")
- still be able to use the `fallbackRule` option

Here is an example:

```ts
// this will only allow query1 and query2.
// query3 for instance will be denied
// it will also deny every mutation
// (you can still use `fallbackRule` option with it)
const permissions = shield({
  Query: {
    "*": deny
    query1: allow,
    query2: allow,
  },
  Mutation: {
    "*": deny
  },
}, {
  fallbackRule: allow
})
```

Thank you