### PR TITLE
Update IRuleFunction and ICacheKeyFn types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -31,12 +31,17 @@ export declare class ILogicRule {
 
 export type IFragment = string
 export type ICache = 'strict' | 'contextual' | 'no_cache' | ICacheKeyFn
-export type ICacheKeyFn = (parent, args, ctx, info) => string
+export type ICacheKeyFn = (
+  parent: any,
+  args: any,
+  ctx: any,
+  info: GraphQLResolveInfo,
+) => string
 export type IRuleResult = boolean | string | Error
 export type IRuleFunction = (
-  parent: object,
+  parent: any,
   args: any,
-  context: any,
+  ctx: any,
   info: GraphQLResolveInfo,
 ) => IRuleResult | Promise<IRuleResult>
 


### PR DESCRIPTION
I noticed that my recent change about typing `parent` as `object` does not work when applying more specific types in the implementation, so I reverted that change.
Also, `ICacheKeyFn` now has correct types added.