### PR TITLE
Fix promise caching bug

### DIFF
--- a/src/rules.ts
+++ b/src/rules.ts
@@ -153,6 +153,12 @@ export class Rule implements IRule {
 
     switch (this.cache) {
       case 'strict': {
+        const hasPromise = Object.keys(args).some(key => {
+          return args[key] instanceof Promise
+        })
+
+        if (hasPromise) return this.name
+
         const key = ctx._shield.hashFunction({ parent, args })
 
         return `${this.name}-${key}`


### PR DESCRIPTION
This is just an approach of fixing the caching problem.
One question I still have: Is it possible that the `args` can be anything else than an `object`?

Should fix #408 I guess and maybe #404 too.