### PR TITLE
implements or chain break early #645

### DIFF
--- a/src/rules.ts
+++ b/src/rules.ts
@@ -301,8 +301,15 @@ export class LogicRule implements ILogicRule {
 
 // Extended Types
 
+const isRuleChain = (rule: ShieldRule): rule is RuleChain => {
+  return typeof (rule as RuleChain).isBreak === 'function'
+}
+
 export class RuleOr extends LogicRule {
   constructor(rules: ShieldRule[]) {
+    if (rules.length === 1 && isRuleChain(rules[0])) {
+      rules[0].isBreak = (res: any) => res === true
+    }
     super(rules)
   }
 
@@ -399,6 +406,9 @@ export class RuleChain extends LogicRule {
     }
   }
 
+  static isBreak = (res: any) => res !== true
+  public isBreak = RuleChain.isBreak
+
   /**
    *
    * @param parent
@@ -420,7 +430,7 @@ export class RuleChain extends LogicRule {
     const tasks = rules.reduce<Promise<IRuleResult[]>>(
       (acc, rule) =>
         acc.then(res => {
-          if (res.some(r => r !== true)) {
+          if (res.some(this.isBreak)) {
             return res
           } else {
             return rule

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -398,7 +398,7 @@ export class RuleChain extends LogicRule {
   ): Promise<IRuleResult> {
     const result = await this.evaluate(parent, args, ctx, info, options)
 
-    if (result.some(res => res !== true)) {
+    if (result.slice(-1).some(res => res !== true)) {
       const customError = result.find(res => res instanceof Error)
       return customError || false
     } else {

--- a/tests/logic.test.ts
+++ b/tests/logic.test.ts
@@ -209,16 +209,20 @@ describe('logic rules', () => {
     /* Permissions */
 
     let allowRuleSequence = []
-    const allowRuleA = rule()(() => {
+    const denyRuleA = rule()(() => {
       allowRuleSequence.push('A')
-      return true
+      return false
     })
     const allowRuleB = rule()(() => {
       allowRuleSequence.push('B')
       return true
     })
-    const allowRuleC = rule()(() => {
+    const denyRuleC = rule()(() => {
       allowRuleSequence.push('C')
+      return true
+    })
+    const allowRuleD = rule()(() => {
+      allowRuleSequence.push('D')
       return true
     })
     let denyRuleCount = 0
@@ -234,7 +238,7 @@ describe('logic rules', () => {
 
     const permissions = shield({
       Query: {
-        allow: or(chain(allowRuleA, allowRuleB, allowRuleC)),
+        allow: or(chain(denyRuleA, allowRuleB, denyRuleC, allowRuleD)),
         deny: or(chain(denyRule, denyRule, denyRule)),
         ruleError: or(chain(ruleWithError, ruleWithError, ruleWithError)),
       },
@@ -260,7 +264,7 @@ describe('logic rules', () => {
       deny: null,
       ruleError: null,
     })
-    expect(allowRuleSequence.toString()).toEqual(['A'].toString())
+    expect(allowRuleSequence.toString()).toEqual(['A', 'B'].toString())
     expect(denyRuleCount).toEqual(3)
     expect(ruleWithErrorCount).toEqual(3)
     expect(res.errors.length).toBe(2)


### PR DESCRIPTION
implements this issue https://github.com/maticzav/graphql-shield/issues/645

##### `or chain` rule

`Or Chain` rule allows you to chain the rules, meaning that rules won't be executed all at once, but one by one until one pass or all fail.

I have not edit the README file because I can't describe it clearly

> The left-most rule is executed first.

##### usage

```ts
// it work only when `or method` has one `chain` rule arguments
or(chain( allowA, allowB, ))
// if `allowA` pass, will stop execute rule, it mean the rule which is after at `allowA`  will not be executed
```

```ts
  test('or chain works as expected', async () => {
    const typeDefs = `
      type Query {
        allow: String
      }
    `

    const resolvers = {
      Query: {
        allow: () => 'allow',
      },
    }

    const schema = makeExecutableSchema({ typeDefs, resolvers })

    /* Permissions */

    let allowRuleSequence = []
    const allowRuleA = rule()(() => {
      allowRuleSequence.push('A')
      return true
    })
    const allowRuleB = rule()(() => {
      allowRuleSequence.push('B')
      return true
    })
    const allowRuleC = rule()(() => {
      allowRuleSequence.push('C')
      return true
    })
 
    const permissions = shield({
      Query: {
        allow: or(chain(allowRuleA, allowRuleB, allowRuleC)),
      },
    })

    const schemaWithPermissions = applyMiddleware(schema, permissions)

    /* Execution */

    const query = `
      query {
        allow
      }
    `
    const res = await graphql(schemaWithPermissions, query)

    /* Tests */

    expect(res.data).toEqual({
      allow: 'allow',
    })
    expect(allowRuleSequence.toString()).toEqual(['A'].toString())
  })
```