### PR TITLE
implement race chain

### DIFF
--- a/src/constructors.ts
+++ b/src/constructors.ts
@@ -9,6 +9,7 @@ import {
   RuleFalse,
   InputRule,
   RuleChain,
+  RuleRaceChain,
 } from './rules'
 
 /**
@@ -96,6 +97,17 @@ export const and = (...rules: ShieldRule[]): RuleAnd => {
  */
 export const chain = (...rules: ShieldRule[]): RuleChain => {
   return new RuleChain(rules)
+}
+
+/**
+ *
+ * @param rule
+ *
+ * Logical operator and serves as a wrapper for and operation.
+ *
+ */
+export const race = (rule: RuleChain): RuleRaceChain => {
+  return new RuleRaceChain(rule)
 }
 
 /**

--- a/src/constructors.ts
+++ b/src/constructors.ts
@@ -9,7 +9,7 @@ import {
   RuleFalse,
   InputRule,
   RuleChain,
-  RuleRaceChain,
+  RuleRace,
 } from './rules'
 
 /**
@@ -101,13 +101,13 @@ export const chain = (...rules: ShieldRule[]): RuleChain => {
 
 /**
  *
- * @param rule
+ * @param rules
  *
  * Logical operator and serves as a wrapper for and operation.
  *
  */
-export const race = (rule: RuleChain): RuleRaceChain => {
-  return new RuleRaceChain(rule)
+export const race = (...rules: ShieldRule[]): RuleRace => {
+  return new RuleRace(rules)
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export {
   deny,
   and,
   chain,
+  race,
   or,
   not,
 } from './constructors'

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -400,7 +400,7 @@ export class RuleChain extends LogicRule {
   }
 
   static isBreak = (res: any) => res !== true
-  public isBreak = RuleChain.isBreak
+  protected isBreak = RuleChain.isBreak
 
   /**
    *
@@ -438,16 +438,9 @@ export class RuleChain extends LogicRule {
   }
 }
 
-export class RuleRaceChain extends RuleChain {
-  constructor(rule: RuleChain) {
-    if (0) {
-      super([])
-    }
-    rule.isBreak = RuleRaceChain.isBreak
-    return rule
-  }
-
+export class RuleRace extends RuleChain {
   static isBreak = (res: any) => res === true
+  protected isBreak = RuleRace.isBreak
 }
 
 export class RuleNot extends LogicRule {

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -391,13 +391,16 @@ export class RuleChain extends LogicRule {
   ): Promise<IRuleResult> {
     const result = await this.evaluate(parent, args, ctx, info, options)
 
-    if (result.some(res => res !== true)) {
+    if (result.slice(-1).some(res => res !== true)) {
       const customError = result.find(res => res instanceof Error)
       return customError || false
     } else {
       return true
     }
   }
+
+  static isBreak = (res: any) => res !== true
+  public isBreak = RuleChain.isBreak
 
   /**
    *
@@ -420,7 +423,7 @@ export class RuleChain extends LogicRule {
     const tasks = rules.reduce<Promise<IRuleResult[]>>(
       (acc, rule) =>
         acc.then(res => {
-          if (res.some(r => r !== true)) {
+          if (res.some(this.isBreak)) {
             return res
           } else {
             return rule
@@ -433,6 +436,18 @@ export class RuleChain extends LogicRule {
 
     return tasks
   }
+}
+
+export class RuleRaceChain extends RuleChain {
+  constructor(rule: RuleChain) {
+    if (0) {
+      super([])
+    }
+    rule.isBreak = RuleRaceChain.isBreak
+    return rule
+  }
+
+  static isBreak = (res: any) => res === true
 }
 
 export class RuleNot extends LogicRule {

--- a/tests/logic.test.ts
+++ b/tests/logic.test.ts
@@ -238,9 +238,9 @@ describe('logic rules', () => {
 
     const permissions = shield({
       Query: {
-        allow: race(chain(denyRuleA, allowRuleB, denyRuleC, allowRuleD)),
-        deny: race(chain(denyRule, denyRule, denyRule)),
-        ruleError: race(chain(ruleWithError, ruleWithError, ruleWithError)),
+        allow: race(denyRuleA, allowRuleB, denyRuleC, allowRuleD),
+        deny: race(denyRule, denyRule, denyRule),
+        ruleError: race(ruleWithError, ruleWithError, ruleWithError),
       },
     })
 


### PR DESCRIPTION
implements this issue https://github.com/maticzav/graphql-shield/issues/645

##### `race chain` rule

`race Chain` rule allows you to chain the rules, meaning that rules won't be executed all at once, but one by one until one pass or all fail.

> The left-most rule is executed first.

I have not edit the README file because I can't describe it clearly

##### usage

```ts
// it work only when `or method` has one `chain` rule arguments
race(chain( allowA, allowB, ))
// if `allowA` pass, will stop execute rule, it mean the rule which is after at `allowA`  will not be executed
```

```ts
  test('race chain works as expected', async () => {
    const typeDefs = `
      type Query {
        allow: String
      }
    `

    const resolvers = {
      Query: {
        allow: () => 'allow',
      },
    }

    const schema = makeExecutableSchema({ typeDefs, resolvers })

    /* Permissions */

    let allowRuleSequence = []
    const allowRuleA = rule()(() => {
      allowRuleSequence.push('A')
      return true
    })
    const allowRuleB = rule()(() => {
      allowRuleSequence.push('B')
      return true
    })
    const allowRuleC = rule()(() => {
      allowRuleSequence.push('C')
      return true
    })
 
    const permissions = shield({
      Query: {
        allow: race(chain(allowRuleA, allowRuleB, allowRuleC)),
      },
    })

    const schemaWithPermissions = applyMiddleware(schema, permissions)

    /* Execution */

    const query = `
      query {
        allow
      }
    `
    const res = await graphql(schemaWithPermissions, query)

    /* Tests */

    expect(res.data).toEqual({
      allow: 'allow',
    })
    expect(allowRuleSequence.toString()).toEqual(['A'].toString())
  })
```