### PR TITLE
fix: await resolver function

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -67,7 +67,7 @@ function generateFieldMiddlewareFromRule(
       const res = await rule.resolve(parent, args, ctx, info, options)
 
       if (res === true) {
-        return resolve(parent, args, ctx, info)
+        return await resolve(parent, args, ctx, info)
       } else if (res === false) {
         return options.fallbackError
       } else {

--- a/tests/fallback.test.ts
+++ b/tests/fallback.test.ts
@@ -14,7 +14,7 @@ describe('fallbackError correctly handles errors', () => {
     `
     const resolvers = {
       Query: {
-        test: () => {
+        test: async () => {
           throw new Error()
         },
       },


### PR DESCRIPTION
If an error is thrown in a resolver and both `debug` and `allowExternalErrors` is false, the fallback error should be returned.

The logic for this is currently correct for synchronous resolvers, but not for asynchronous resolvers.

This PR adds the following:
- Awaits the resolver function for a result. This allows an asynchronous resolver to throw within the `try...catch` around the call.
- Converts the existing test to an `async` resolver.

Removing the changes in `src/generator.ts`, but keeping the `async` resolver in the test, will result in the tests failing.