### PR TITLE
Feat: support function/mapper for fallback error option

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,32 @@ const permissions = shield(
     fallbackError: new CustomError('You are something special!'),
   },
 )
+
+const permissions = shield(
+  {
+    Query: {
+      items: allow,
+    },
+  },
+  {
+    fallbackError: (err, parent, args, context, info) => {
+      if (thrownThing instanceof ApolloError) {
+        // expected errors
+        return thrownThing
+      } else if (thrownThing instanceof Error) {
+        // unexpected errors
+        console.error(thrownThing)
+        await Sentry.report(thrownThing)
+        return new ApolloError('Internal server error', 'ERR_INTERNAL_SERVER')
+      } else {
+        // what the hell got thrown
+        console.error('The resolver threw something that is not an error.')
+        console.error(thrownThing)
+        return new ApolloError('Internal server error', 'ERR_INTERNAL_SERVER')
+      }
+    },
+  },
+)
 ```
 
 ### Fragments

--- a/README.md
+++ b/README.md
@@ -242,13 +242,23 @@ type IRules = ShieldRule | IRuleTypeMap
 
 type IHashFunction = (arg: { parent: any; args: any }) => string
 
+type IFallbackErrorMapperType = (
+  err: unknown,
+  parent: object,
+  args: object,
+  ctx: IShieldContext,
+  info: GraphQLResolveInfo,
+) => Promise<Error> | Error
+
+export type IFallbackErrorType = Error | IFallbackErrorMapperType
+
 // Generator Options
 
 interface IOptions {
   debug?: boolean
   allowExternalErrors?: boolean
   fallbackRule?: ShieldRule
-  fallbackError?: string | Error
+  fallbackError?: string | IFallbackErrorType
   hashFunction?: IHashFunction
 }
 

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -69,6 +69,9 @@ function generateFieldMiddlewareFromRule(
       if (res === true) {
         return await resolve(parent, args, ctx, info)
       } else if (res === false) {
+        if (typeof options.fallbackError === 'function') {
+          return await options.fallbackError(null, parent, args, ctx, info)
+        }
         return options.fallbackError
       } else {
         return res
@@ -79,6 +82,9 @@ function generateFieldMiddlewareFromRule(
       } else if (options.allowExternalErrors) {
         return err
       } else {
+        if (typeof options.fallbackError === 'function') {
+          return await options.fallbackError(err, parent, args, ctx, info)
+        }
         return options.fallbackError
       }
     }

--- a/src/shield.ts
+++ b/src/shield.ts
@@ -7,6 +7,7 @@ import {
   IOptionsConstructor,
   ShieldRule,
   IHashFunction,
+  IFallbackErrorType,
 } from './types'
 import { generateMiddlewareGeneratorFromRuleTree } from './generator'
 import { allow } from './constructors'
@@ -29,9 +30,9 @@ function normalizeOptions(options: IOptionsConstructor): IOptions {
     debug: options.debug !== undefined ? options.debug : false,
     allowExternalErrors: withDefault(false)(options.allowExternalErrors),
     fallbackRule: withDefault<ShieldRule>(allow)(options.fallbackRule),
-    fallbackError: withDefault(new Error('Not Authorised!'))(
-      options.fallbackError,
-    ),
+    fallbackError: withDefault<IFallbackErrorType>(
+      new Error('Not Authorised!'),
+    )(options.fallbackError),
     hashFunction: withDefault<IHashFunction>(hash)(options.hashFunction),
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,13 +86,23 @@ export type IRules = ShieldRule | IRuleTypeMap
 
 export type IHashFunction = (arg: { parent: any; args: any }) => string
 
+export type IFallbackErrorMapperType = (
+  err: unknown,
+  parent: object,
+  args: object,
+  ctx: IShieldContext,
+  info: GraphQLResolveInfo,
+) => Promise<Error> | Error
+
+export type IFallbackErrorType = Error | IFallbackErrorMapperType
+
 // Generator Options
 
 export interface IOptions {
   debug: boolean
   allowExternalErrors: boolean
   fallbackRule: ShieldRule
-  fallbackError: Error
+  fallbackError: IFallbackErrorType
   hashFunction: IHashFunction
 }
 
@@ -100,7 +110,7 @@ export interface IOptionsConstructor {
   debug?: boolean
   allowExternalErrors?: boolean
   fallbackRule?: ShieldRule
-  fallbackError?: string | Error
+  fallbackError?: string | IFallbackErrorType
   hashFunction?: IHashFunction
 }
 


### PR DESCRIPTION
Closes https://github.com/maticzav/graphql-shield/issues/601

This allows stuff such as:

```ts
const fallbackError = async (thrownThing, parent, args, context, info) => {
  // expected errors
  if (thrownThing instanceof ApolloError) {
    return thrownThing
  } else if (thrownThing instanceof Error) {
    // unexpected errors
    console.error(thrownThing)
    await Sentry.report(thrownThing)
    return new ApolloError("Internal server error", "ERR_INTERNAL_SERVER")
  } else {
    // what the hell got thrown
    console.error("The resolver threw something that is not an error.")
    console.error(thrownThing)
    return new ApolloError("Internal server error", "ERR_INTERNAL_SERVER")
  }
}
```