### PR TITLE
Fix/errors async

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,8 @@ const admin = rule({ cache: 'no_cache' })(async (parent, args, ctx, info) => {
 
 ##### Custom Errors
 
+**Important: Shield will always return errors, never throw them.**
+
 Shield, by default, catches all errors thrown during resolver execution. This way we can be 100% sure none of your internal logic can be exposed to the client if it was not meant to be.
 
 To return custom error messages to your client, you can return error instead of throwing it. This way, Shield knows it's not a bug but rather a design decision under control. Besides returning an error you can also return a `string` representing a custom error message.

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -23,6 +23,7 @@ import {
   isRule,
   isLogicRule,
   withDefault,
+  RuleResolutionError,
 } from './utils'
 import { ValidationError } from './validation'
 import { IMiddlewareWithOptions } from 'graphql-middleware/dist/types'
@@ -68,9 +69,10 @@ function generateFieldMiddlewareFromRule(
 
       if (res === true) {
         return await resolve(parent, args, ctx, info)
-      } else if (res === false) {
+      } else if (res === false || res instanceof RuleResolutionError) {
         if (typeof options.fallbackError === 'function') {
-          return await options.fallbackError(null, parent, args, ctx, info)
+          const err = res instanceof RuleResolutionError ? res.cause : null
+          return await options.fallbackError(err, parent, args, ctx, info)
         }
         return options.fallbackError
       } else {

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -13,7 +13,7 @@ import {
   IOptions,
   IShieldContext,
 } from './types'
-import { isLogicRule } from './utils'
+import { isLogicRule, RuleResolutionError } from './utils'
 import { GraphQLResolveInfo } from 'graphql'
 import { isUndefined } from 'util'
 
@@ -71,7 +71,7 @@ export class Rule implements IRule {
       if (options.debug) {
         throw err
       } else {
-        return false
+        return new RuleResolutionError(err)
       }
     }
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -98,3 +98,12 @@ export function withDefault<T>(fallback: T): (value: T | undefined) => T {
     return value
   }
 }
+
+export class RuleResolutionError extends Error {
+  cause: Error
+
+  constructor(cause: Error) {
+    super()
+    this.cause = cause
+  }
+}

--- a/tests/fallback.test.ts
+++ b/tests/fallback.test.ts
@@ -160,10 +160,13 @@ describe('fallbackError correctly handles errors', () => {
 
     /* Permissions */
 
-    const fallbackError = () => new Error('fallback')
+    const fallbackError = (err) => {
+      if (err) return err
+      return new Error('fallback')
+    }
 
     const allow = rule()(() => {
-      throw new Error()
+      throw new Error('unexpected')
     })
 
     const permissions = shield(
@@ -189,7 +192,7 @@ describe('fallbackError correctly handles errors', () => {
     /* Tests */
 
     expect(res.data).toBeNull()
-    expect(res.errors[0].message).toBe(fallbackError().message)
+    expect(res.errors[0].message).toBe('unexpected')
   })
 
   test('error in resolver can be mapped.', async () => {
@@ -203,7 +206,7 @@ describe('fallbackError correctly handles errors', () => {
     const resolvers = {
       Query: {
         test: async () => {
-          throw new Error()
+          throw new Error('unexpected')
         },
       },
     }
@@ -215,7 +218,10 @@ describe('fallbackError correctly handles errors', () => {
 
     /* Permissions */
 
-    const fallbackError = () => new Error('fallback')
+    const fallbackError = (err) => {
+      if (err) return err
+      return new Error('fallback')
+    }
 
     const permissions = shield(
       {
@@ -240,7 +246,7 @@ describe('fallbackError correctly handles errors', () => {
     /* Tests */
 
     expect(res.data).toBeNull()
-    expect(res.errors[0].message).toBe(fallbackError().message)
+    expect(res.errors[0].message).toBe('unexpected')
   })
 })
 


### PR DESCRIPTION
Fixes https://github.com/maticzav/graphql-shield/issues/739
This is the only none-breaking change way that I found of doing this.
I also added a warning in the `README` since another user complained the other day that shield is returning errors instead of throwing them.