### PR TITLE
Throw errors instead of returning them.

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -80,12 +80,12 @@ function generateFieldMiddlewareFromRule(
       if (options.debug) {
         throw err
       } else if (options.allowExternalErrors) {
-        return err
+        throw err
       } else {
         if (typeof options.fallbackError === 'function') {
-          return await options.fallbackError(err, parent, args, ctx, info)
+          throw await options.fallbackError(err, parent, args, ctx, info)
         }
-        return options.fallbackError
+        throw options.fallbackError
       }
     }
   }


### PR DESCRIPTION
Fixes #740 

@jahudka could you explain the idea behind why throwing errors is wrong as opposed to returning them?

I can merge the PR afterwards.