### PR TITLE
Ensure rule.resolve doesn't swallow errors

### DIFF
--- a/src/rules.ts
+++ b/src/rules.ts
@@ -70,8 +70,10 @@ export class Rule implements IRule {
     } catch (err) {
       if (options.debug) {
         throw err
-      } else {
+      } else if (err instanceof Error) {
         return err
+      } else {
+        return false
       }
     }
   }

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -71,7 +71,7 @@ export class Rule implements IRule {
       if (options.debug) {
         throw err
       } else {
-        return false
+        return err
       }
     }
   }


### PR DESCRIPTION
We're moving to graphql-shield from an @auth directive to take advantage of more complex per-field and per-type validations offered, however we've found runtime errors are swallowed inside a rule (they don't make it to `options.fallbackError`):

e.g.
```js
const isAdmin = rule()((parent, args, context: Context) => {
    return context.thisDoesNotExist.bang; // TypeError: Cannot read property 'bang' of undefined
});
```

The above rule correctly returns an unauthorized error to the client which is great, but we lose the underlying runtime error so  our logging service never knows there was a runtime error, and instead thinks the user was merely unauthorised.

We're therefore having to effectively wrap all our rules in a catch like this which is boilerplate we'd like to avoid -- and obviously that boilerplate could error at which point it's lost again:
```
const isAdmin = rule()((parent, args, context: Context) => {
   try {
     return context.thisDoesNotExist.bang; // TypeError: Cannot read property 'bang' of undefined
   } catch(ex) {
     return ex;
   }
});
```

