### PR TITLE
Make fallbackError async in the Apollo example

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,7 +556,7 @@ const permissions = shield(
     },
   },
   {
-    fallbackError: (thrownThing, parent, args, context, info) => {
+    fallbackError: async (thrownThing, parent, args, context, info) => {
       if (thrownThing instanceof ApolloError) {
         // expected errors
         return thrownThing


### PR DESCRIPTION
Reason:

`await Sentry.report(thrownThing)` further down