### PR TITLE
fix: change Not Authorised to Not Authorized

### DIFF
--- a/packages/graphql-shield/src/shield.ts
+++ b/packages/graphql-shield/src/shield.ts
@@ -23,7 +23,7 @@ function normalizeOptions(options: IOptionsConstructor): IOptions {
     debug: options.debug !== undefined ? options.debug : false,
     allowExternalErrors: withDefault(false)(options.allowExternalErrors),
     fallbackRule: withDefault<ShieldRule>(allow)(options.fallbackRule),
-    fallbackError: withDefault<IFallbackErrorType>(new Error('Not Authorised!'))(options.fallbackError),
+    fallbackError: withDefault<IFallbackErrorType>(new Error('Not Authorized!'))(options.fallbackError),
     hashFunction: withDefault<IHashFunction>(hash)(options.hashFunction),
   }
 }

--- a/packages/graphql-shield/tests/fallback.test.ts
+++ b/packages/graphql-shield/tests/fallback.test.ts
@@ -352,7 +352,7 @@ describe('external errors can be controled correctly', () => {
     /* Tests */
 
     expect(res.data).toBeNull()
-    expect(res.errors?.[0]?.message).toBe('Not Authorised!')
+    expect(res.errors?.[0]?.message).toBe('Not Authorized!')
   })
 })
 

--- a/packages/graphql-shield/tests/logic.test.ts
+++ b/packages/graphql-shield/tests/logic.test.ts
@@ -409,8 +409,8 @@ describe('logic rules', () => {
       customRuleErrorString: 'customRuleErrorString',
     })
     expect(res.errors?.map((err) => err.message)).toEqual([
-      'Not Authorised!',
-      'Not Authorised!',
+      'Not Authorized!',
+      'Not Authorized!',
     ])
   })
 

--- a/website/src/pages/docs/advanced/troubleshooting.mdx
+++ b/website/src/pages/docs/advanced/troubleshooting.mdx
@@ -2,7 +2,7 @@
 
 > This is a list of frequently asked questions and their short explanations.
 
-## When a single field is "Not Authorised!" the entire parent object returns null.
+## When a single field is "Not Authorized!" the entire parent object returns null.
 
 This occurs when a non-nullable field (specified in the schema) returns a null value (due to GraphQL Shield blocking the field's value). GraphQL is a strongly typed language - the schema serves as a contract between client and server - which requires that the server response follow the schema definition.
 

--- a/website/src/pages/docs/errors.mdx
+++ b/website/src/pages/docs/errors.mdx
@@ -68,7 +68,7 @@ If you wish to see errors thrown inside resolvers, you can set `allowExternalErr
 
 ## Global Fallback Error
 
-GraphQL Shield allows you to set a globally defined fallback error that is used instead of `Not Authorised!` default response. This might be particularly useful for localization. You can use `string` or even custom `Error` to define it.
+GraphQL Shield allows you to set a globally defined fallback error that is used instead of `Not Authorized!` default response. This might be particularly useful for localization. You can use `string` or even custom `Error` to define it.
 
 ```ts
 const permissions = shield(

--- a/website/src/pages/docs/shield.mdx
+++ b/website/src/pages/docs/shield.mdx
@@ -58,7 +58,7 @@ const permissions = shield({
 | allowExternalErrors | false    | false                                                | Toggle catching internal errors.                   |
 | debug               | false    | false                                                | Toggle debug mode.                                 |
 | fallbackRule        | false    | allow                                                | The default rule for every "rule-undefined" field. |
-| fallbackError       | false    | Error('Not Authorised!')                             | Error Permission system fallbacks to.              |
+| fallbackError       | false    | Error('Not Authorized!')                             | Error Permission system fallbacks to.              |
 | hashFunction        | false    | [object-hash](https://github.com/puleos/object-hash) | Hashing function to use for `strict` cache         |
 
-By default `shield` ensures no internal data is exposed to client if it was not meant to be. Therefore, all thrown errors during execution resolve in `Not Authorised!` error message if not otherwise specified using `error` wrapper. This can be turned off by setting `allowExternalErrors` option to `true`.
+By default `shield` ensures no internal data is exposed to client if it was not meant to be. Therefore, all thrown errors during execution resolve in `Not Authorized!` error message if not otherwise specified using `error` wrapper. This can be turned off by setting `allowExternalErrors` option to `true`.


### PR DESCRIPTION
This PR is to fix the spelling of `Authorised` to `Authorized`. 
<img width="903" alt="Screenshot 2024-03-18 at 4 02 36 PM" src="https://github.com/dimatill/graphql-shield/assets/16469185/e1fccc08-b52b-470d-ae2c-23c2be2df0bb">
