### PR TITLE
fix: Changed judgment of undefined to not use a function

### DIFF
--- a/packages/graphql-shield/src/rules.ts
+++ b/packages/graphql-shield/src/rules.ts
@@ -15,7 +15,6 @@ import {
 } from './types.js'
 import { isLogicRule } from './utils.js'
 import { GraphQLResolveInfo } from 'graphql'
-import { isUndefined } from 'util'
 
 export class Rule implements IRule {
   readonly name: string
@@ -387,7 +386,7 @@ export class RuleChain extends LogicRule {
     async function iterate([rule, ...otherRules]: ShieldRule[]): Promise<
       IRuleResult[]
     > {
-      if (isUndefined(rule)) return []
+      if (rule === undefined) return []
       return rule.resolve(parent, args, ctx, info, options).then((res) => {
         if (res !== true) {
           return [res]
@@ -441,7 +440,7 @@ export class RuleRace extends LogicRule {
     async function iterate([rule, ...otherRules]: ShieldRule[]): Promise<
       IRuleResult[]
     > {
-      if (isUndefined(rule)) return []
+      if (rule === undefined) return []
       return rule.resolve(parent, args, ctx, info, options).then((res) => {
         if (res === true) {
           return [res]


### PR DESCRIPTION
## Overview

Changed to not use [`isUndefined`](https://nodejs.org/api/util.html#utilisundefinedobject), which is deprecated in Node.js.

## Reason for change

As written in the overview, it is deprecated in Node.js. I changed it because it is possible to determine without using it.

Also, this may be a personal opinion, but I use this library with Cloudflare Workers. There are two options to use Node.js API with Cloudflare Workers.

- [node_compat](https://developers.cloudflare.com/workers/wrangler/configuration/#add-polyfills-using-wrangler)
- [nodejs_compat](https://developers.cloudflare.com/workers/wrangler/configuration/#use-runtime-apis-directly)

I won't go into detail on how these two options are different, but the only way to make this library work is to use the former `node_compat`. Because to use the `nodejs_compat` option, you need to specify `node:` (`node:util` in this library) when using the Node.js API.

Initially, I used this library with the `node_compat` option, but started to migrate to using the `nodejs_compat` option. However, I noticed that this library cannot be built with the `nodejs_compat` option. Those are the `isUndefined` and `util` in this case.
I could have patched it to reference `node:util`, but when I looked at the Node.js documentation I noticed that it was deprecated, so I submitted a pull request to fix the library.